### PR TITLE
Bug/example missing semicolon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
       os: linux
       env:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
-        - CXXFLAGS=""
     # Latest gcc
     - name: Latest gcc7
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ script:
   - make examples/trivialvendingmachine
   - make examples/fancyvendingmachine
   - make examples/beatmachine
+  - make examples/resuminggraph
   - make docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
         - CXXFLAGS=""  # -Werror=strict-aliasing and other GCC bugs
-      script:
-        - make unit-test/test_all
-        - make examples/all
     # Latest gcc
     - name: Latest gcc7
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
       os: linux
       env:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
+        - CXXFLAGS=""  # -Werror=strict-aliasing and other GCC bugs
+      script:
+        - make unit-test/test_all
+        - make examples/all
     # Latest gcc
     - name: Latest gcc7
       os: linux
@@ -34,7 +38,7 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
   - sudo apt-get -qq update
-  - sudo apt-get install -y graphviz doxygen
+  - sudo apt-get install -y graphviz doxygen libeigen3-dev
   - $CXX --version
 
 script:

--- a/examples/resuminggraph.cpp
+++ b/examples/resuminggraph.cpp
@@ -307,7 +307,7 @@ DetectorGraph::StateSnapshot ReadSnapshot(const DetectorGraph::StateSnapshot& pr
 //![main]
 int main()
 {
-    DetectorGraph::StateSnapshot primeSnapshot = GetPrimeSnapshot()
+    DetectorGraph::StateSnapshot primeSnapshot = GetPrimeSnapshot();
     DetectorGraph::StateSnapshot resumeSnapshot = ReadSnapshot(primeSnapshot);
 
     ResumingGraph resumingGraph = ResumingGraph(resumeSnapshot);

--- a/makefile
+++ b/makefile
@@ -107,6 +107,11 @@ examples/robotlocalization:
 	# file.
 	$(CXX) $(CPPSTD) $(CXXFLAGS) $(CONFIG) -g -I$(CORE_INCLUDE) -I$(PLATFORM) -I$(UTIL) $(FULL_SRCS) $(PLATFORM_SRCS) $(UTIL_SRCS) examples/robotlocalization.cpp -o robotlocalization.out && ./robotlocalization.out
 
+examples/beatmachine:
+	# Keeping a separate rule for this example so that we don't run it as it
+	# takes way too long to run it (2mins!)
+	$(CXX) $(CPPSTD) $(CXXFLAGS) $(CONFIG) -g -I$(CORE_INCLUDE) -I$(PLATFORM) -I$(UTIL) $(FULL_SRCS) $(PLATFORM_SRCS) $(UTIL_SRCS) examples/beatmachine.cpp -o beatmachine.out
+
 examples/%:
 	# General Purpose Example building rule.
 	$(CXX) $(CPPSTD) $(CXXFLAGS) $(CONFIG) -g -I$(CORE_INCLUDE) -I$(PLATFORM) -I$(UTIL) $(FULL_SRCS) $(PLATFORM_SRCS) $(UTIL_SRCS) $@.cpp -o $(@:examples/%=%.out) && ./$(@:examples/%=%.out)


### PR DESCRIPTION
New example added in previous PR had a missing semicolon.
That went in because building that example wasn't part of the required automation bits.
This PR fixes the semicolon and adds that to the automation/Build list.